### PR TITLE
Add CLI analytics option to angular.json

### DIFF
--- a/blokhutfeest/angular.json
+++ b/blokhutfeest/angular.json
@@ -102,5 +102,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }


### PR DESCRIPTION
## Summary
- disable Angular CLI analytics

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_687aa6a766988325ab2f2b64590f4c2a